### PR TITLE
remove dependency of react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,5 @@
     "type": "git",
     "url": "git@github.com:leofidjeland/react-native-barcode.git"
   },
-  "dependencies": {
-    "react-native": "^0.8.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Hi @LeoFidjeland , 

Great work on the package! My experience using this package has been great so far.

I encountered an error today saying **Error: Naming collision detected**. And I fixed it by removing **react-native** from dependencies. I've seldom seen packages adding **react-native** as a dependency, esp. when the sole use case of the package is with **react-native** presented.

Let me know what you think.

Thanks,

Huang
